### PR TITLE
docs: doc string for return_random_number() corrected

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -96,11 +96,10 @@ def return_random_number() -> int:
     ...
 
     Args:
-    a: float
-    b: float
+    no args
 
     Returns:
-    float
+    int
     '''
 
     return np.random.randint(0, 100)


### PR DESCRIPTION
# Description

The documentation of return_random_numer() was corrected.
- resolves #9 


# Type of change
- **docs**: Input arguments were removed from documentation, as the function has no input arguments. The type of the returned variable was adjusted to reflect the actual type of the returned variable.
